### PR TITLE
Add logout button

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -154,7 +154,16 @@ class _AdminPanelState extends State<AdminPanel> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Panel de administración')),
+      appBar: AppBar(
+        title: const Text('Panel de administración'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.logout),
+            tooltip: 'Cerrar sesión',
+            onPressed: () => FirebaseAuth.instance.signOut(),
+          ),
+        ],
+      ),
       body: Padding(
         padding: const EdgeInsets.all(16),
         child: ListView(


### PR DESCRIPTION
## Summary
- add a logout button in the admin panel AppBar

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ff359cf7c8328a87a212d46357053