### PR TITLE
Add modular admin dashboard

### DIFF
--- a/lib/pages/activations_page.dart
+++ b/lib/pages/activations_page.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+
+class ActivationsPage extends StatefulWidget {
+  const ActivationsPage({super.key});
+
+  @override
+  State<ActivationsPage> createState() => _ActivationsPageState();
+}
+
+class _ActivationsPageState extends State<ActivationsPage> {
+  final List<Map<String, String>> activations = [
+    {
+      'date': '2024-01-01 10:00',
+      'user': 'admin@example.com',
+      'status': 'éxito'
+    },
+    {
+      'date': '2024-01-02 12:30',
+      'user': 'user@example.com',
+      'status': 'fallo'
+    },
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: const [
+            Expanded(child: Text('Filtros aquí')),
+          ],
+        ),
+        const SizedBox(height: 10),
+        Expanded(
+          child: ListView.builder(
+            itemCount: activations.length,
+            itemBuilder: (context, index) {
+              final act = activations[index];
+              return ListTile(
+                title: Text(act['date']!),
+                subtitle: Text('${act['user']} - Estado: ${act['status']}'),
+                trailing: IconButton(
+                  icon: const Icon(Icons.info_outline),
+                  onPressed: () {
+                    showDialog(
+                      context: context,
+                      builder: (context) {
+                        return AlertDialog(
+                          title: const Text('Detalle de activación'),
+                          content: const Text('Mapa y datos de contacto'),
+                          actions: [
+                            TextButton(
+                              onPressed: () => Navigator.pop(context),
+                              child: const Text('Cerrar'),
+                            ),
+                          ],
+                        );
+                      },
+                    );
+                  },
+                ),
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/pages/dashboard_page.dart
+++ b/lib/pages/dashboard_page.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+
+class DashboardPage extends StatelessWidget {
+  const DashboardPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Wrap(
+            spacing: 16,
+            runSpacing: 16,
+            children: const [
+              _MetricCard(title: 'Usuarios registrados', value: '120'),
+              _MetricCard(title: 'Alertas reales', value: '8'),
+              _MetricCard(title: 'Alertas falsas', value: '3'),
+              _MetricCard(title: 'Alertas accidentales', value: '5'),
+            ],
+          ),
+          const SizedBox(height: 20),
+          const Text('Gráficos de alertas', style: TextStyle(fontSize: 18)),
+          const SizedBox(height: 10),
+          Container(
+            height: 200,
+            color: Colors.black12,
+            alignment: Alignment.center,
+            child: const Text('Gráficos aquí'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MetricCard extends StatelessWidget {
+  final String title;
+  final String value;
+
+  const _MetricCard({required this.title, required this.value});
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: SizedBox(
+        width: 200,
+        height: 80,
+        child: Center(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(value, style: const TextStyle(fontSize: 24)),
+              Text(title),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/recordings_page.dart
+++ b/lib/pages/recordings_page.dart
@@ -1,0 +1,43 @@
+import 'dart:html' as html;
+import 'package:flutter/material.dart';
+
+class RecordingsPage extends StatelessWidget {
+  const RecordingsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final recordings = [
+      'audio1.mp3',
+      'audio2.mp3',
+    ];
+
+    return ListView.builder(
+      itemCount: recordings.length,
+      itemBuilder: (context, index) {
+        final file = recordings[index];
+        return ListTile(
+          title: Text(file),
+          trailing: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              IconButton(
+                icon: const Icon(Icons.play_arrow),
+                onPressed: () {
+                  final audio = html.AudioElement(file)..play();
+                },
+              ),
+              IconButton(
+                icon: const Icon(Icons.download),
+                onPressed: () {
+                  html.AnchorElement(href: file)
+                    ..download = file
+                    ..click();
+                },
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+
+class SettingsPage extends StatefulWidget {
+  const SettingsPage({super.key});
+
+  @override
+  State<SettingsPage> createState() => _SettingsPageState();
+}
+
+class _SettingsPageState extends State<SettingsPage> {
+  double recordingDuration = 30;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      padding: const EdgeInsets.all(16),
+      children: [
+        const Text('Duración de grabación', style: TextStyle(fontSize: 18)),
+        Slider(
+          min: 30,
+          max: 60,
+          divisions: 3,
+          value: recordingDuration,
+          label: recordingDuration.round().toString(),
+          onChanged: (v) => setState(() => recordingDuration = v),
+        ),
+        Text('Seleccionada: ${recordingDuration.round()}s'),
+        const SizedBox(height: 20),
+        const Text('Clasificación de alertas', style: TextStyle(fontSize: 18)),
+        const Text('Personalización pendiente'),
+        const SizedBox(height: 20),
+        const Text('Parámetros de detección', style: TextStyle(fontSize: 18)),
+        const Text('Ajustes de umbrales y sensibilidad pendiente'),
+      ],
+    );
+  }
+}

--- a/lib/pages/users_page.dart
+++ b/lib/pages/users_page.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+
+class UsersPage extends StatefulWidget {
+  const UsersPage({super.key});
+
+  @override
+  State<UsersPage> createState() => _UsersPageState();
+}
+
+class _UsersPageState extends State<UsersPage> {
+  final TextEditingController userController = TextEditingController();
+  final TextEditingController searchController = TextEditingController();
+  final TextEditingController editController = TextEditingController();
+  final List<Map<String, String>> users = [
+    {'name': 'admin@example.com', 'role': 'admin'},
+    {'name': 'user@example.com', 'role': 'subadmin'},
+  ];
+
+  List<Map<String, String>> get filteredUsers {
+    final query = searchController.text.toLowerCase();
+    if (query.isEmpty) return users;
+    return users
+        .where((u) => u['name']!.toLowerCase().contains(query))
+        .toList();
+  }
+
+  void _addUser() {
+    final text = userController.text;
+    if (text.isNotEmpty) {
+      setState(() {
+        users.add({'name': text, 'role': 'subadmin'});
+        userController.clear();
+      });
+    }
+  }
+
+  void _editUser(int index) {
+    editController.text = users[index]['name']!;
+    showDialog(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('Editar usuario'),
+          content: TextField(controller: editController),
+          actions: [
+            TextButton(
+              onPressed: () {
+                setState(() {
+                  users[index]['name'] = editController.text;
+                });
+                Navigator.of(context).pop();
+              },
+              child: const Text('Guardar'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  void _deleteUser(int index) {
+    setState(() {
+      users.removeAt(index);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Expanded(
+              child: TextField(
+                controller: userController,
+                decoration:
+                    const InputDecoration(labelText: 'Nuevo usuario'),
+              ),
+            ),
+            const SizedBox(width: 8),
+            ElevatedButton(onPressed: _addUser, child: const Text('Crear')),
+          ],
+        ),
+        const SizedBox(height: 10),
+        TextField(
+          controller: searchController,
+          decoration: const InputDecoration(labelText: 'Buscar'),
+          onChanged: (_) => setState(() {}),
+        ),
+        const SizedBox(height: 10),
+        Expanded(
+          child: ListView.builder(
+            itemCount: filteredUsers.length,
+            itemBuilder: (context, index) {
+              final user = filteredUsers[index];
+              return ListTile(
+                title: Text(user['name']!),
+                subtitle: Text('Rol: ${user['role']}'),
+                trailing: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    IconButton(
+                      icon: const Icon(Icons.edit),
+                      onPressed: () => _editUser(index),
+                    ),
+                    IconButton(
+                      icon: const Icon(Icons.delete),
+                      onPressed: () => _deleteUser(index),
+                    ),
+                  ],
+                ),
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- build a more complete admin web layout
- add sidebar navigation with Dashboard, Users, Activations, Recordings and Settings pages
- implement dummy 2FA dialog on login
- add placeholder metrics, user list management with search and other stub pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ff41bc3b08328a6c2dab673de0d85