### PR TITLE
Remove 2FA check from login

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -57,32 +57,7 @@ class _LoginPageState extends State<LoginPage> {
         email: emailController.text,
         password: passwordController.text,
       );
-      final otpOk = await showDialog<bool>(
-            context: context,
-            builder: (context) {
-              final controller = TextEditingController();
-              return AlertDialog(
-                title: const Text('Código 2FA'),
-                content: TextField(
-                  controller: controller,
-                  decoration:
-                      const InputDecoration(labelText: 'Ingrese el código'),
-                ),
-                actions: [
-                  TextButton(
-                    onPressed: () =>
-                        Navigator.of(context).pop(controller.text == '123456'),
-                    child: const Text('Validar'),
-                  )
-                ],
-              );
-            },
-          ) ??
-          false;
-      if (!otpOk) {
-        await FirebaseAuth.instance.signOut();
-        setState(() => error = 'Código 2FA incorrecto');
-      }
+      // 2FA authentication removed
     } on FirebaseAuthException catch (e) {
       if (e.code == 'user-not-found') {
         setState(() => error = 'Cuenta no encontrada');


### PR DESCRIPTION
## Summary
- remove the OTP dialog logic so login doesn't require 2FA

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ff6b52304832896a8325935f16fc9