### PR TITLE
Add admin contact info fields

### DIFF
--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 
 class SettingsPage extends StatefulWidget {
   const SettingsPage({super.key});
@@ -9,6 +11,49 @@ class SettingsPage extends StatefulWidget {
 
 class _SettingsPageState extends State<SettingsPage> {
   double recordingDuration = 30;
+
+  final TextEditingController nameController = TextEditingController();
+  final TextEditingController phoneController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    _loadContactInfo();
+  }
+
+  Future<void> _loadContactInfo() async {
+    final user = FirebaseAuth.instance.currentUser;
+    if (user == null) return;
+    final doc = await FirebaseFirestore.instance
+        .collection('admins')
+        .doc(user.uid)
+        .get();
+    if (doc.exists) {
+      nameController.text = doc['name'] ?? '';
+      phoneController.text = doc['phone'] ?? '';
+    }
+  }
+
+  Future<void> _saveContactInfo() async {
+    final user = FirebaseAuth.instance.currentUser;
+    if (user == null) return;
+    await FirebaseFirestore.instance.collection('admins').doc(user.uid).set({
+      'name': nameController.text,
+      'phone': phoneController.text,
+      'email': user.email,
+    });
+    if (mounted) {
+      ScaffoldMessenger.of(context)
+          .showSnackBar(const SnackBar(content: Text('Información guardada')));
+    }
+  }
+
+  @override
+  void dispose() {
+    nameController.dispose();
+    phoneController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -31,6 +76,22 @@ class _SettingsPageState extends State<SettingsPage> {
         const SizedBox(height: 20),
         const Text('Parámetros de detección', style: TextStyle(fontSize: 18)),
         const Text('Ajustes de umbrales y sensibilidad pendiente'),
+        const SizedBox(height: 20),
+        const Text('Contacto del administrador', style: TextStyle(fontSize: 18)),
+        Text('Cuenta: ${FirebaseAuth.instance.currentUser?.email ?? ''}'),
+        TextField(
+          controller: nameController,
+          decoration: const InputDecoration(labelText: 'Nombre'),
+        ),
+        TextField(
+          controller: phoneController,
+          decoration: const InputDecoration(labelText: 'Teléfono'),
+        ),
+        const SizedBox(height: 8),
+        ElevatedButton(
+          onPressed: _saveContactInfo,
+          child: const Text('Guardar'),
+        ),
       ],
     );
   }


### PR DESCRIPTION
## Summary
- include Cloud Firestore and Firebase Auth in settings
- load and save contact info in Firestore using the signed in user
- add form inputs in settings page to store admin contact details

## Testing
- `dart analyze` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68500d5077808328a9ef19c4bbe612b0