### PR TITLE
Fix loading of admin contact info

### DIFF
--- a/lib/pages/activations_page.dart
+++ b/lib/pages/activations_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../utils/contact_info.dart';
 
 class ActivationsPage extends StatefulWidget {
   const ActivationsPage({super.key});
@@ -42,13 +43,23 @@ class _ActivationsPageState extends State<ActivationsPage> {
                 subtitle: Text('${act['user']} - Estado: ${act['status']}'),
                 trailing: IconButton(
                   icon: const Icon(Icons.info_outline),
-                  onPressed: () {
+                  onPressed: () async {
+                    final info = await loadContactInfo();
+                    if (!context.mounted) return;
                     showDialog(
                       context: context,
                       builder: (context) {
                         return AlertDialog(
                           title: const Text('Detalle de activación'),
-                          content: const Text('Mapa y datos de contacto'),
+                          content: Column(
+                            mainAxisSize: MainAxisSize.min,
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text('Nombre: ${info['name']}'),
+                              Text('Teléfono: ${info['phone']}'),
+                              Text('Email: ${info['email']}'),
+                            ],
+                          ),
                           actions: [
                             TextButton(
                               onPressed: () => Navigator.pop(context),

--- a/lib/pages/history_page.dart
+++ b/lib/pages/history_page.dart
@@ -1,5 +1,6 @@
 import 'dart:html' as html;
 import 'package:flutter/material.dart';
+import '../utils/contact_info.dart';
 
 class HistoryPage extends StatelessWidget {
   const HistoryPage({super.key});
@@ -60,13 +61,23 @@ class HistoryPage extends StatelessWidget {
                     ),
                     IconButton(
                       icon: const Icon(Icons.info_outline),
-                      onPressed: () {
+                      onPressed: () async {
+                        final info = await loadContactInfo();
+                        if (!context.mounted) return;
                         showDialog(
                           context: context,
                           builder: (context) {
                             return AlertDialog(
                               title: const Text('Detalle de activación'),
-                              content: const Text('Mapa y datos de contacto'),
+                              content: Column(
+                                mainAxisSize: MainAxisSize.min,
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  Text('Nombre: ${info['name']}'),
+                                  Text('Teléfono: ${info['phone']}'),
+                                  Text('Email: ${info['email']}'),
+                                ],
+                              ),
                               actions: [
                                 TextButton(
                                   onPressed: () => Navigator.pop(context),

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import '../utils/contact_info.dart';
 
 class SettingsPage extends StatefulWidget {
   const SettingsPage({super.key});
@@ -22,40 +23,11 @@ class _SettingsPageState extends State<SettingsPage> {
   }
 
   Future<void> _loadContactInfo() async {
-    final user = FirebaseAuth.instance.currentUser;
-    if (user == null) return;
-
-    final adminDoc = await FirebaseFirestore.instance
-        .collection('admins')
-        .doc(user.uid)
-        .get();
-
-    final globalDoc = await FirebaseFirestore.instance
-        .collection('config')
-        .doc('contact_info')
-        .get();
-
+    final info = await loadContactInfo();
     if (!mounted) return;
-
-    String? name;
-    String? phone;
-
-    if (adminDoc.exists) {
-      name = adminDoc['name'];
-      phone = adminDoc['phone'];
-    }
-
-    if ((name == null || name.isEmpty) && globalDoc.exists) {
-      name = globalDoc['name'];
-    }
-
-    if ((phone == null || phone.isEmpty) && globalDoc.exists) {
-      phone = globalDoc['phone'];
-    }
-
     setState(() {
-      nameController.text = name ?? '';
-      phoneController.text = phone ?? '';
+      nameController.text = info['name'] ?? '';
+      phoneController.text = info['phone'] ?? '';
     });
   }
 

--- a/lib/utils/contact_info.dart
+++ b/lib/utils/contact_info.dart
@@ -1,0 +1,46 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+/// Loads contact information for the current admin or the global config.
+Future<Map<String, String>> loadContactInfo() async {
+  final user = FirebaseAuth.instance.currentUser;
+
+  String? name;
+  String? phone;
+  String? email;
+
+  if (user != null) {
+    final adminDoc = await FirebaseFirestore.instance
+        .collection('admins')
+        .doc(user.uid)
+        .get();
+    if (adminDoc.exists) {
+      name = adminDoc.data()?['name'] as String?;
+      phone = adminDoc.data()?['phone'] as String?;
+      email = adminDoc.data()?['email'] as String?;
+    }
+  }
+
+  final globalDoc = await FirebaseFirestore.instance
+      .collection('config')
+      .doc('contact_info')
+      .get();
+
+  if ((name == null || name.isEmpty) && globalDoc.exists) {
+    name = globalDoc.data()?['name'] as String?;
+  }
+
+  if ((phone == null || phone.isEmpty) && globalDoc.exists) {
+    phone = globalDoc.data()?['phone'] as String?;
+  }
+
+  if ((email == null || email.isEmpty) && globalDoc.exists) {
+    email = globalDoc.data()?['email'] as String?;
+  }
+
+  return {
+    'name': name ?? '',
+    'phone': phone ?? '',
+    'email': email ?? '',
+  };
+}


### PR DESCRIPTION
## Summary
- centralize admin contact retrieval in `utils/contact_info.dart`
- load this info in Settings page
- show contact details in history and activations dialogs

## Testing
- `dart format -o none lib/utils/contact_info.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850cdb245088328aefaa0f4fc691e04