### PR TITLE
Reload settings after saving contact info

### DIFF
--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -49,6 +49,7 @@ class _SettingsPageState extends State<SettingsPage> {
       'phone': phoneController.text,
       'email': user.email,
     });
+    await _loadContactInfo();
     if (mounted) {
       ScaffoldMessenger.of(context)
           .showSnackBar(const SnackBar(content: Text('Información guardada')));


### PR DESCRIPTION
## Summary
- reload contact info after saving settings so the latest values display

## Testing
- `flutter doctor` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850d7608c848328845ab31262c13cad