### PR TITLE
Remove global contact info document

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,5 +18,5 @@ La configuración de hosting está definida en `firebase.json`.
 ## Contacto del administrador
 
 La información de contacto que se introduce en la sección de configuración se
-guarda también en Firestore en el documento `config/contact_info`. La aplicación
-móvil puede consultar esa ruta para mostrar estos datos al usuario.
+almacena únicamente en Firestore dentro del documento `admins/<uid>` asociado al
+administrador. La aplicación móvil lee estos datos desde esa ubicación.

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -44,11 +44,6 @@ class _SettingsPageState extends State<SettingsPage> {
       'email': user.email,
     });
 
-    await FirebaseFirestore.instance.collection('config').doc('contact_info').set({
-      'name': nameController.text,
-      'phone': phoneController.text,
-      'email': user.email,
-    });
     await _loadContactInfo();
     if (mounted) {
       ScaffoldMessenger.of(context)

--- a/lib/utils/contact_info.dart
+++ b/lib/utils/contact_info.dart
@@ -1,7 +1,7 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 
-/// Loads contact information for the current admin or the global config.
+/// Loads contact information for the current admin.
 Future<Map<String, String>> loadContactInfo() async {
   final user = FirebaseAuth.instance.currentUser;
 
@@ -19,23 +19,6 @@ Future<Map<String, String>> loadContactInfo() async {
       phone = adminDoc.data()?['phone'] as String?;
       email = adminDoc.data()?['email'] as String?;
     }
-  }
-
-  final globalDoc = await FirebaseFirestore.instance
-      .collection('config')
-      .doc('contact_info')
-      .get();
-
-  if ((name == null || name.isEmpty) && globalDoc.exists) {
-    name = globalDoc.data()?['name'] as String?;
-  }
-
-  if ((phone == null || phone.isEmpty) && globalDoc.exists) {
-    phone = globalDoc.data()?['phone'] as String?;
-  }
-
-  if ((email == null || email.isEmpty) && globalDoc.exists) {
-    email = globalDoc.data()?['email'] as String?;
   }
 
   return {


### PR DESCRIPTION
## Summary
- drop reading from `config/contact_info`
- save admin contact info only under `admins/<uid>`
- update README accordingly

## Testing
- `dart --version` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6850daedd614832896d4bd7a449da246